### PR TITLE
Update FAWE to support WORLDEDIT flag.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,8 @@
       <dependency>
          <groupId>com.boydti</groupId>
          <artifactId>fawe-api</artifactId>
-         <version>18.07.27-3ed2e57-1163-20.5.2</version>
+         <version>latest</version>
+         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>net.ess3</groupId>

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/FAWEHelper.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/FAWEHelper.java
@@ -13,7 +13,7 @@ public class FAWEHelper
 {
 	@Getter private final WorldGuardExtraFlagsPlugin plugin;
 	@Getter private final Plugin fawePlugin;
-	
+
 	public void onEnable()
 	{
 		FaweAPI.addMaskManager(new FaweWorldEditFlagMaskManager(this.plugin));

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/FaweWorldEditFlagMaskManager.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/FaweWorldEditFlagMaskManager.java
@@ -1,93 +1,111 @@
 package net.goldtreeservers.worldguardextraflags.fawe;
 
-import org.bukkit.Location;
+import com.boydti.fawe.regions.general.RegionFilter;
+import com.sk89q.worldedit.BlockVector;
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.regions.AbstractRegion;
+import com.sk89q.worldguard.protection.flags.Flags;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-
 import com.boydti.fawe.object.FawePlayer;
 import com.boydti.fawe.regions.FaweMask;
 import com.boydti.fawe.regions.FaweMaskManager;
 import com.sk89q.worldguard.LocalPlayer;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.StateFlag.State;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 import net.goldtreeservers.worldguardextraflags.WorldGuardExtraFlagsPlugin;
-import net.goldtreeservers.worldguardextraflags.flags.Flags;
+
 import net.goldtreeservers.worldguardextraflags.wg.legacy.wrappers.RegionManagerWrapper;
 
-public class FaweWorldEditFlagMaskManager extends FaweMaskManager<Player> 
+public class FaweWorldEditFlagMaskManager extends FaweMaskManager<Player>
 {
 	private final WorldGuardExtraFlagsPlugin plugin;
 	
-	public FaweWorldEditFlagMaskManager(WorldGuardExtraFlagsPlugin plugin)
+	FaweWorldEditFlagMaskManager(WorldGuardExtraFlagsPlugin plugin)
 	{
 		super(plugin.getName());
-		
 		this.plugin = plugin;
 	}
-	
-    public ProtectedRegion getRegion(Player player, Location loc)
-    {
-        final com.sk89q.worldguard.LocalPlayer localplayer = this.plugin.getWorldGuardCommunicator().wrapPlayer(player);
-        RegionManagerWrapper manager = this.plugin.getWorldGuardCommunicator().getRegionContainer().get(player.getWorld());
-        final ProtectedRegion global = manager.getRegion("__global__");
-        if (global != null && !isDenied(localplayer, global))
-        {
-            return global;
-        }
-        
-        final ApplicableRegionSet regions = manager.getApplicableRegions(player.getLocation());
-        for (final ProtectedRegion region : regions)
-        {
-            if (!isDenied(localplayer, region))
-            {
-                return region;
-            }
-        }
-        return null;
-    }
-
-    public boolean isDenied(LocalPlayer localplayer, ProtectedRegion region)
-    {
-        return region.getFlag(Flags.WORLDEDIT) == State.DENY;
-    }
 
 	@Override
-	public FaweMask getMask(FawePlayer<Player> fawePlayer)
+	public RegionFilter getFilter(String world)
 	{
-		return null; //Problems here due to FaweMask using LocalWorld
-		
-		/*final Player player = fawePlayer.parent;
-		final Location location = player.getLocation();
-        final ProtectedRegion myregion = this.getRegion(player, location);
-        
-        if (myregion != null)
-        {
-            final BlockVector pos1;
-            final BlockVector pos2;
-            if (myregion.getId().equals("__global__"))
-            {
-                pos1 = new BlockVector(Integer.MIN_VALUE, 0, Integer.MIN_VALUE);
-                pos2 = new BlockVector(Integer.MAX_VALUE, 255, Integer.MAX_VALUE);
-            }
-            else
-            {
-                pos1 = new BlockVector(myregion.getMinimumPoint().getBlockX(), myregion.getMinimumPoint().getBlockY(), myregion.getMinimumPoint().getBlockZ());
-                pos2 = new BlockVector(myregion.getMaximumPoint().getBlockX(), myregion.getMaximumPoint().getBlockY(), myregion.getMaximumPoint().getBlockZ());
-            }
-            
-            return new FaweMask(pos1, pos2)
-            {
-                @Override
-                public String getName()
-                {
-                    return myregion.getId();
-                }
-            };
-        }
-        else
-        {
-            return null;
-        }*/
+		return new WorldGuardFilter(plugin, Bukkit.getWorld(world));
 	}
+
+	@Override
+	public FaweMask getMask(FawePlayer<Player> fp, MaskType type)
+	{
+		final Player player = fp.parent;
+		final LocalPlayer localplayer = this.plugin.getWorldGuardCommunicator().wrapPlayer(player);
+		RegionManagerWrapper manager = this.plugin.getWorldGuardCommunicator().getRegionContainer().get(player.getWorld());
+
+		return new FaweMask(new MultiRegion(manager, localplayer), null)
+		{
+			@Override
+			public boolean isValid(FawePlayer player, MaskType type)
+			{
+				// We rely on the region mask instead of this
+				return true;
+			}
+		};
+	}
+
+	/***
+	 * ManagerRegion wraps a RegionManager and will provide results based upon the regions enclosed
+	 */
+	private static class MultiRegion extends AbstractRegion
+	{
+		private final RegionManagerWrapper manager;
+		private final LocalPlayer localplayer;
+
+		MultiRegion(RegionManagerWrapper manager, LocalPlayer localplayer)
+		{
+			super(null);
+			this.manager = manager;
+			this.localplayer = localplayer;
+		}
+
+		@Override
+		public Vector getMinimumPoint()
+		{
+			return manager.getRegions().entrySet().stream()
+					.map(s -> s.getValue().getMinimumPoint())
+					.min(Vector::compareTo)
+					.orElse(new BlockVector(Integer.MIN_VALUE, 0, Integer.MIN_VALUE));
+		}
+
+		@Override
+		public Vector getMaximumPoint()
+		{
+			return manager.getRegions().entrySet().stream()
+					.map(s -> s.getValue().getMaximumPoint())
+					.min(Vector::compareTo)
+					.orElse(new BlockVector(Integer.MAX_VALUE, 0, Integer.MAX_VALUE));
+		}
+
+		@Override
+		public void expand(Vector... changes) {
+			throw new UnsupportedOperationException("Region is immutable");
+		}
+
+		@Override
+		public void contract(Vector... changes) {
+			throw new UnsupportedOperationException("Region is immutable");
+		}
+
+		@Override
+		public boolean contains(Vector position)
+		{
+			// Make sure that all these flags are not denied. Denies override allows.
+			return  manager.getApplicableRegions(position).testState(
+					localplayer,
+					Flags.BUILD,
+					Flags.BLOCK_PLACE,
+					Flags.BLOCK_BREAK,
+					net.goldtreeservers.worldguardextraflags.flags.Flags.WORLDEDIT
+			);
+		}
+
+	}
+
 }

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/FaweWorldEditFlagMaskManager.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/FaweWorldEditFlagMaskManager.java
@@ -35,8 +35,8 @@ public class FaweWorldEditFlagMaskManager extends FaweMaskManager<Player>
 	@Override
 	public FaweMask getMask(FawePlayer<Player> fp, MaskType type)
 	{
-		final Player player = fp.parent;
-		final LocalPlayer localplayer = this.plugin.getWorldGuardCommunicator().wrapPlayer(player);
+		Player player = fp.parent;
+		LocalPlayer localplayer = this.plugin.getWorldGuardCommunicator().wrapPlayer(player);
 		RegionManagerWrapper manager = this.plugin.getWorldGuardCommunicator().getRegionContainer().get(player.getWorld());
 
 		return new FaweMask(new MultiRegion(manager, localplayer), null)
@@ -79,8 +79,8 @@ public class FaweWorldEditFlagMaskManager extends FaweMaskManager<Player>
 		{
 			return manager.getRegions().entrySet().stream()
 					.map(s -> s.getValue().getMaximumPoint())
-					.min(Vector::compareTo)
-					.orElse(new BlockVector(Integer.MAX_VALUE, 0, Integer.MAX_VALUE));
+					.max(Vector::compareTo)
+					.orElse(new BlockVector(Integer.MAX_VALUE, 256, Integer.MAX_VALUE));
 		}
 
 		@Override
@@ -96,14 +96,19 @@ public class FaweWorldEditFlagMaskManager extends FaweMaskManager<Player>
 		@Override
 		public boolean contains(Vector position)
 		{
-			// Make sure that all these flags are not denied. Denies override allows.
-			return  manager.getApplicableRegions(position).testState(
+			boolean canWorldEdit = manager.getApplicableRegions(position).testState(
 					localplayer,
-					Flags.BUILD,
-					Flags.BLOCK_PLACE,
-					Flags.BLOCK_BREAK,
 					net.goldtreeservers.worldguardextraflags.flags.Flags.WORLDEDIT
 			);
+
+			boolean canBuild = manager.getApplicableRegions(position).testState(
+						localplayer,
+						Flags.BUILD,
+						Flags.BLOCK_PLACE,
+						Flags.BLOCK_BREAK
+			);
+
+			return canWorldEdit && canBuild;
 		}
 
 	}

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/WorldGuardFilter.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/WorldGuardFilter.java
@@ -16,16 +16,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WorldGuardFilter extends CuboidRegionFilter
 {
-	private final World world;
-	private boolean large;
-	private RegionManagerWrapper manager;
 	private WorldGuardExtraFlagsPlugin plugin;
+	private final World world;
+	private RegionManagerWrapper manager;
+
+	private boolean large;
+
 
 	WorldGuardFilter(WorldGuardExtraFlagsPlugin plugin, World world)
 	{
 		checkNotNull(world);
-		this.world = world;
 		this.plugin = plugin;
+		this.world = world;
+		this.manager = plugin.getWorldGuardCommunicator().getRegionContainer().get(world);
 	}
 
 	@Override
@@ -36,7 +39,6 @@ public class WorldGuardFilter extends CuboidRegionFilter
 			@Override
 			public void run(Object value)
 			{
-				WorldGuardFilter.this.manager = plugin.getWorldGuardCommunicator().getRegionContainer().get(world);
 				for (ProtectedRegion region : manager.getRegions().values())
 				{
 					BlockVector min = region.getMinimumPoint();
@@ -56,7 +58,9 @@ public class WorldGuardFilter extends CuboidRegionFilter
 	@Override
 	public boolean containsChunk(int chunkX, int chunkZ)
 	{
-		if (!large) return super.containsChunk(chunkX, chunkZ);
+		if (!large) {
+			return super.containsChunk(chunkX, chunkZ);
+		}
 		BlockVector pos1 = new BlockVector(chunkX << 4, 0, chunkZ << 4);
 		BlockVector pos2 = new BlockVector(pos1.getBlockX() + 15, 255, pos1.getBlockZ() + 15);
 		ProtectedCuboidRegion chunkRegion = new ProtectedCuboidRegion("unimportant", pos1, pos2);
@@ -67,7 +71,9 @@ public class WorldGuardFilter extends CuboidRegionFilter
 	@Override
 	public boolean containsRegion(int mcaX, int mcaZ)
 	{
-		if (!large) return super.containsRegion(mcaX, mcaZ);
+		if (!large) {
+			return super.containsRegion(mcaX, mcaZ);
+		}
 		BlockVector pos1 = new BlockVector(mcaX << 9, 0, mcaZ << 9);
 		BlockVector pos2 = new BlockVector(pos1.getBlockX() + 511, 255, pos1.getBlockZ() + 511);
 		ProtectedCuboidRegion regionRegion = new ProtectedCuboidRegion("unimportant", pos1, pos2);

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/WorldGuardFilter.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/fawe/WorldGuardFilter.java
@@ -1,0 +1,77 @@
+package net.goldtreeservers.worldguardextraflags.fawe;
+
+import com.boydti.fawe.Fawe;
+import com.boydti.fawe.object.RunnableVal;
+import com.boydti.fawe.regions.general.CuboidRegionFilter;
+import com.boydti.fawe.util.TaskManager;
+import com.sk89q.worldedit.BlockVector;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import net.goldtreeservers.worldguardextraflags.WorldGuardExtraFlagsPlugin;
+import net.goldtreeservers.worldguardextraflags.wg.legacy.wrappers.RegionManagerWrapper;
+import org.bukkit.World;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class WorldGuardFilter extends CuboidRegionFilter
+{
+	private final World world;
+	private boolean large;
+	private RegionManagerWrapper manager;
+	private WorldGuardExtraFlagsPlugin plugin;
+
+	WorldGuardFilter(WorldGuardExtraFlagsPlugin plugin, World world)
+	{
+		checkNotNull(world);
+		this.world = world;
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void calculateRegions()
+	{
+		TaskManager.IMP.sync(new RunnableVal<Object>()
+		{
+			@Override
+			public void run(Object value)
+			{
+				WorldGuardFilter.this.manager = plugin.getWorldGuardCommunicator().getRegionContainer().get(world);
+				for (ProtectedRegion region : manager.getRegions().values())
+				{
+					BlockVector min = region.getMinimumPoint();
+					BlockVector max = region.getMaximumPoint();
+					if (max.getBlockX() - min.getBlockX() > 1024 || max.getBlockZ() - min.getBlockZ() > 1024)
+					{
+						Fawe.debug("Large or complex region shapes cannot be optimized. Filtering will be slower");
+						large = true;
+						break;
+					}
+					add(min.toVector2D(), max.toVector2D());
+				}
+			}
+		});
+	}
+
+	@Override
+	public boolean containsChunk(int chunkX, int chunkZ)
+	{
+		if (!large) return super.containsChunk(chunkX, chunkZ);
+		BlockVector pos1 = new BlockVector(chunkX << 4, 0, chunkZ << 4);
+		BlockVector pos2 = new BlockVector(pos1.getBlockX() + 15, 255, pos1.getBlockZ() + 15);
+		ProtectedCuboidRegion chunkRegion = new ProtectedCuboidRegion("unimportant", pos1, pos2);
+		ApplicableRegionSet set = manager.getApplicableRegions(chunkRegion);
+		return set.size() > 0 && !set.getRegions().iterator().next().getId().equals("__global__");
+	}
+
+	@Override
+	public boolean containsRegion(int mcaX, int mcaZ)
+	{
+		if (!large) return super.containsRegion(mcaX, mcaZ);
+		BlockVector pos1 = new BlockVector(mcaX << 9, 0, mcaZ << 9);
+		BlockVector pos2 = new BlockVector(pos1.getBlockX() + 511, 255, pos1.getBlockZ() + 511);
+		ProtectedCuboidRegion regionRegion = new ProtectedCuboidRegion("unimportant", pos1, pos2);
+		ApplicableRegionSet set = manager.getApplicableRegions(regionRegion);
+		return set.size() > 0 && !set.getRegions().iterator().next().getId().equals("__global__");
+	}
+}


### PR DESCRIPTION
# Current
It looks like FAWE is not supported properly yet in here. I wasn't sure what the comment (Uses Local World) meant or its implications.

I've also wanted FAWE to support WorldGuard Flags better in addition to those provided by this plugin and have submitted a PR at https://github.com/boy0001/WorldEdit/pull/2. However this PR here neither depends on it nor will conflict with it if merged as it implements all the same changes.

# Proposed
This PR edits the mask manager provided in this plugin to:
1. It attempts to make use of WorldGuard state flags when determining if a mask is valid. We check if (BUILD, BLOCK_BREAK, BLOCK_PLACE, WORLDEDIT) return true.

2. The player's location is no longer that important apart from determining the World. It is the mask that defines operations.

# Potential Issues
1. The height in EditSession is checked via an extent only if regions are not used. Perhaps it needs to be a fall-through extent instead that denies if its outside range but falls through to the next extent otherwise (which will require a final extent to actually allow). I noticed pasting a LARGE schematic that went above the map height caused an exception but am not sure if the Mask is the correct place to check this.

2. I'm not sure how much this will affect performance, hence it's optional via a permission.

3. I'm not sure how non WE commands are affected.
