### PR TITLE
Add "totem-of-undying" and "enchanted-golden-apple" flags.

### DIFF
--- a/Spigot/src/main/java/net/goldtreeservers/worldguardextraflags/listeners/PlayerListener.java
+++ b/Spigot/src/main/java/net/goldtreeservers/worldguardextraflags/listeners/PlayerListener.java
@@ -1,10 +1,12 @@
 package net.goldtreeservers.worldguardextraflags.listeners;
 
 import org.bukkit.Material;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityResurrectEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
@@ -208,6 +210,24 @@ public class PlayerListener implements Listener
 		if (value != null)
 		{
 			player.setAllowFlight(value);
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPlayerResurrectEvent(EntityResurrectEvent event)
+	{
+		LivingEntity entity = event.getEntity();
+		if (!(entity instanceof Player)) {
+			return;
+		}
+
+		Player player = (Player) entity;
+		ApplicableRegionSet regions = this.plugin.getWorldGuardCommunicator().getRegionContainer().createQuery().getApplicableRegions(player.getLocation());
+		
+		State totemOfUndying = WorldGuardUtils.queryValue(player, player.getWorld(), regions.getRegions(), Flags.TOTEM_OF_UNDYING);
+		if (totemOfUndying == State.DENY)
+		{
+			event.setCancelled(true);
 		}
 	}
 }

--- a/WG/src/main/java/net/goldtreeservers/worldguardextraflags/flags/Flags.java
+++ b/WG/src/main/java/net/goldtreeservers/worldguardextraflags/flags/Flags.java
@@ -51,6 +51,8 @@ public final class Flags
 	
 	public final static StateFlag FLY = new StateFlag("fly", false);
 	
+	public final static StateFlag TOTEM_OF_UNDYING = new StateFlag("totem-of-undying", true);
+	
 	public final static SetFlag<SoundData> PLAY_SOUNDS = new SetFlag<SoundData>("play-sounds", new SoundDataFlag(null));
 	
 	public final static StateFlag MYTHICMOB_EGGS = new StateFlag("mythicmobs-eggs", true);

--- a/WG/src/main/java/net/goldtreeservers/worldguardextraflags/flags/Flags.java
+++ b/WG/src/main/java/net/goldtreeservers/worldguardextraflags/flags/Flags.java
@@ -52,6 +52,7 @@ public final class Flags
 	public final static StateFlag FLY = new StateFlag("fly", false);
 	
 	public final static StateFlag TOTEM_OF_UNDYING = new StateFlag("totem-of-undying", true);
+	public final static StateFlag ENCHANTED_GOLDEN_APPLE = new StateFlag("enchanted-golden-apple", true);
 	
 	public final static SetFlag<SoundData> PLAY_SOUNDS = new SetFlag<SoundData>("play-sounds", new SoundDataFlag(null));
 	

--- a/WG/src/main/java/net/goldtreeservers/worldguardextraflags/wg/wrappers/WorldGuardCommunicator.java
+++ b/WG/src/main/java/net/goldtreeservers/worldguardextraflags/wg/wrappers/WorldGuardCommunicator.java
@@ -61,6 +61,7 @@ public interface WorldGuardCommunicator
 		flagRegistry.register(Flags.ITEM_DURABILITY);
 		flagRegistry.register(Flags.JOIN_LOCATION);
 		flagRegistry.register(Flags.TOTEM_OF_UNDYING);
+		flagRegistry.register(Flags.ENCHANTED_GOLDEN_APPLE);
 	}
 	
 	default public void onEnable(Plugin plugin) throws Exception

--- a/WG/src/main/java/net/goldtreeservers/worldguardextraflags/wg/wrappers/WorldGuardCommunicator.java
+++ b/WG/src/main/java/net/goldtreeservers/worldguardextraflags/wg/wrappers/WorldGuardCommunicator.java
@@ -60,6 +60,7 @@ public interface WorldGuardCommunicator
 		flagRegistry.register(Flags.CHUNK_UNLOAD);
 		flagRegistry.register(Flags.ITEM_DURABILITY);
 		flagRegistry.register(Flags.JOIN_LOCATION);
+		flagRegistry.register(Flags.TOTEM_OF_UNDYING);
 	}
 	
 	default public void onEnable(Plugin plugin) throws Exception


### PR DESCRIPTION
As part of developing plugins for a server, I needed a way to disable Totem of Undying and Enchanted Golden Apples on a per-region basis. I ended up modifying this plugin to meet those needs, and I'm making a pull request to give back to the community as official features.

## Flags

**`totem-of-undying` [allow/deny/none, default allow]**  
Prevents Totem of Undying from resurrecting players, and instead causes them to die normally.

**`enchanted-golden-apple` [allow/deny/none, default allow]**
Disables the special effects of enchanted golden apples, and causes them to behave like normal golden apples when eaten.

## Implementation Details

**`totem-of-undying`**
According to the documentation for `EntityResurrectEvent`, it will be called with a `cancelled` state even if the player does not have a totem in their inventory, presumably to allow plugins to create custom ways to revive players or living entities. As far as I can tell, there is no way to determine if a totem was the cause for resurrection, so I gave WorldGuardExtraFlags the lowest priority to avoid any potential conflicts. 

**`enchanted-golden-apple`**
Unfortunately, there isn't a safe way to disable the default effects of food items like golden apples. I had to work around it by cancelling the event and reimplementing the logic to remove the apple and apply the normal effects given to players with the regular golden apple. It's not the most ideal way to go about it, but the other alternatives I could think of were significantly worse options.