### PR TITLE
Fix spawn location event

### DIFF
--- a/Spigot/src/main/java/net/goldtreeservers/worldguardextraflags/listeners/PlayerListener.java
+++ b/Spigot/src/main/java/net/goldtreeservers/worldguardextraflags/listeners/PlayerListener.java
@@ -190,9 +190,9 @@ public class PlayerListener implements Listener
 	{
 		Player player = event.getPlayer();
 		
-		ApplicableRegionSet regions = this.plugin.getWorldGuardCommunicator().getRegionContainer().createQuery().getApplicableRegions(player.getLocation());
+		ApplicableRegionSet regions = this.plugin.getWorldGuardCommunicator().getRegionContainer().createQuery().getApplicableRegions(event.getSpawnLocation());
 		
-		Object location = WorldGuardUtils.queryValueUnchecked(player, player.getWorld(), regions.getRegions(), Flags.JOIN_LOCATION);
+		Object location = WorldGuardUtils.queryValueUnchecked(player, event.getSpawnLocation().getWorld(), regions.getRegions(), Flags.JOIN_LOCATION);
 		if (location != null)
 		{
 			event.setSpawnLocation(WorldEditUtils.toLocation(location));


### PR DESCRIPTION
This fixes compatibility of the `join-location` with other plugins that change a player's spawn location.

Previously moving the spawn location of a player out of a region with the `join-location` flag set was not possible with another plugin modifying the spawn location in the event due WorldGuardExtraFlags using the old player location from the Player object to query the flag and not the (potentially) modified location from the event.